### PR TITLE
add --deep_git_clone flag

### DIFF
--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -15,6 +15,41 @@ import (
 // Cloner is a function that can clone a git repo.
 type Cloner func(repoSpec *RepoSpec) error
 
+// DeepClonerUsingGitExec uses a local git install
+// to obtain a full-depth clone of a remote repo
+func DeepClonerUsingGitExec(repoSpec *RepoSpec) error {
+	gitProgram, err := exec.LookPath("git")
+	if err != nil {
+		return errors.Wrap(err, "no 'git' program on path")
+	}
+	repoSpec.Dir, err = filesys.NewTmpConfirmedDir()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(
+		gitProgram,
+		"clone",
+		repoSpec.CloneSpec(),
+		repoSpec.Dir.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "trouble cloning %s", repoSpec.OrgRepo)
+	}
+	if repoSpec.Ref == "" {
+		repoSpec.Ref = "master"
+	}
+	cmd = exec.Command(gitProgram, "checkout", repoSpec.Ref)
+	cmd.Dir = repoSpec.Dir.String()
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrapf(
+			err, "trouble checking out href %s", repoSpec.Ref)
+	}
+	return nil
+}
+
 // ClonerUsingGitExec uses a local git install, as opposed
 // to say, some remote API, to obtain a local clone of
 // a remote repo.

--- a/api/internal/loadertest/fakeloader.go
+++ b/api/internal/loadertest/fakeloader.go
@@ -34,7 +34,8 @@ func NewFakeLoaderWithRestrictor(
 	// Create fake filesystem and inject it into initial Loader.
 	fSys := filesys.MakeFsInMemory()
 	fSys.Mkdir(initialDir)
-	ldr, err := loader.NewLoader(lr, initialDir, fSys)
+	dc := false
+	ldr, err := loader.NewLoader(lr, initialDir, fSys, dc)
 	if err != nil {
 		log.Fatalf("Unable to make loader: %v", err)
 	}

--- a/api/internal/target/plugindir_test.go
+++ b/api/internal/target/plugindir_test.go
@@ -57,8 +57,9 @@ metadata:
 		t.Fatalf("err %v", err)
 	}
 
+	dc := false
 	ldr, err := fLdr.NewLoader(
-		fLdr.RestrictionRootOnly, dir, fSys)
+		fLdr.RestrictionRootOnly, dir, fSys, dc)
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -54,7 +54,8 @@ func (b *Kustomizer) Run(path string) (resmap.ResMap, error) {
 	if b.options.LoadRestrictions == types.LoadRestrictionsRootOnly {
 		lr = fLdr.RestrictionRootOnly
 	}
-	ldr, err := fLdr.NewLoader(lr, path, b.fSys)
+
+	ldr, err := fLdr.NewLoader(lr, path, b.fSys, b.options.DoDeepGitClone)
 	if err != nil {
 		return nil, err
 	}

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -18,6 +18,10 @@ type Options struct {
 	// order as specified by the kustomization file(s).
 	DoLegacyResourceSort bool
 
+	// When true, use full-depth git clone, in order to allow
+	// reference to a specific commit
+	DoDeepGitClone bool
+
 	// Restrictions on what can be loaded from the file system.
 	// See type definition.
 	LoadRestrictions types.LoadRestrictions
@@ -33,6 +37,7 @@ type Options struct {
 func MakeDefaultOptions() *Options {
 	return &Options{
 		DoLegacyResourceSort: true,
+		DoDeepGitClone:       false,
 		LoadRestrictions:     types.LoadRestrictionsRootOnly,
 		DoPrune:              false,
 		PluginConfig:         konfig.DisabledPluginConfig(),

--- a/api/loader/loader.go
+++ b/api/loader/loader.go
@@ -18,17 +18,21 @@ import (
 // the remote bases will all be root-only restricted.
 func NewLoader(
 	lr LoadRestrictorFunc,
-	target string, fSys filesys.FileSystem) (ifc.Loader, error) {
+	target string, fSys filesys.FileSystem, deepClone bool) (ifc.Loader, error) {
+	cloner := git.ClonerUsingGitExec
+	if deepClone {
+		cloner = git.DeepClonerUsingGitExec
+	}
 	repoSpec, err := git.NewRepoSpecFromUrl(target)
 	if err == nil {
 		// The target qualifies as a remote git target.
 		return newLoaderAtGitClone(
-			repoSpec, fSys, nil, git.ClonerUsingGitExec)
+			repoSpec, fSys, nil, cloner)
 	}
 	root, err := demandDirectoryRoot(fSys, target)
 	if err != nil {
 		return nil, err
 	}
 	return newLoaderAtConfirmedDir(
-		lr, root, fSys, nil, git.ClonerUsingGitExec), nil
+		lr, root, fSys, nil, cloner), nil
 }

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -47,6 +47,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
+github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1/YsqVWoWNLQO+fusocsw354rqGTZtAgw=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -131,6 +132,7 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -304,6 +306,7 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -76,6 +76,7 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 	addFlagLoadRestrictor(cmd.Flags())
 	addFlagEnablePlugins(cmd.Flags())
 	addFlagReorderOutput(cmd.Flags())
+	addFlagEnableDeepClone(cmd.Flags())
 	cmd.AddCommand(NewCmdBuildPrune(out))
 	return cmd
 }
@@ -105,6 +106,7 @@ func (o *Options) makeOptions() *krusty.Options {
 		DoLegacyResourceSort: o.outOrder == legacy,
 		LoadRestrictions:     getFlagLoadRestrictorValue(),
 		DoPrune:              false,
+		DoDeepGitClone:       isFlagEnableDeepCloneSet(),
 	}
 	if isFlagEnablePluginsSet() {
 		c, err := konfig.EnabledPluginConfig()

--- a/kustomize/internal/commands/build/flagenabledeepclone.go
+++ b/kustomize/internal/commands/build/flagenabledeepclone.go
@@ -1,0 +1,29 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	flagEnableDeepCloneName = "enable_deep_clone"
+	flagEnableDeepCloneHelp = `enable deep git cloning.
+See https://github.com/kubernetes-sigs/kustomize/issues/1452
+`
+)
+
+var (
+	flagEnableDeepCloneValue = false
+)
+
+func addFlagEnableDeepClone(set *pflag.FlagSet) {
+	set.BoolVar(
+		&flagEnableDeepCloneValue, flagEnableDeepCloneName,
+		false, flagEnableDeepCloneHelp)
+}
+
+func isFlagEnableDeepCloneSet() bool {
+	return flagEnableDeepCloneValue
+}


### PR DESCRIPTION
restores the behaviour of <= 2.0.3 for specified refs, fixing https://github.com/kubernetes-sigs/kustomize/issues/1452